### PR TITLE
Support for 7zip server archive files

### DIFF
--- a/src/Modules/Setup.cs
+++ b/src/Modules/Setup.cs
@@ -192,8 +192,8 @@ namespace NFive.PluginManager.Modules
 		private async Task InstallFiveM(string path, string source)
 		{
 			var platformName = RuntimeEnvironment.IsWindows ? "Windows" : "Linux";
+			var platformUrl = RuntimeEnvironment.IsWindows ? "build_server_windows" : "build_proot_linux";
 			var platformFile = RuntimeEnvironment.IsWindows ? $"({Regex.Escape("server.zip")}|{Regex.Escape("server.7z")})" : "(fx.tar.xz)";
-			var platformFile = ServerFileRegexTokens(RuntimeEnvironment.IsWindows);
 			var platformPath = RuntimeEnvironment.IsWindows ? Path.Combine(path) : Path.Combine(path, "alpine", "opt", "cfx-server");
 
 			if (!string.IsNullOrWhiteSpace(source) && File.Exists(source))

--- a/src/Modules/Setup.cs
+++ b/src/Modules/Setup.cs
@@ -98,34 +98,34 @@ namespace NFive.PluginManager.Modules
 
 				var config = new ConfigGenerator
 				{
-					//Hostname = string.IsNullOrWhiteSpace(this.ServerName) ? Input.String("server name", "NFive") : this.ServerName,
-					//MaxPlayers = this.MaxPlayers ?? Convert.ToUInt16(Input.Int("server max players", 1, 128, 32)),
-					//Locale = string.IsNullOrWhiteSpace(this.Locale) ? Input.String("server locale", "en-US", s =>
-					//{
-					//	if (Regex.IsMatch(s, @"[a-z]{2}-[A-Z]{2}")) return true;
+					Hostname = string.IsNullOrWhiteSpace(this.ServerName) ? Input.String("server name", "NFive") : this.ServerName,
+					MaxPlayers = this.MaxPlayers ?? Convert.ToUInt16(Input.Int("server max players", 1, 128, 32)),
+					Locale = string.IsNullOrWhiteSpace(this.Locale) ? Input.String("server locale", "en-US", s =>
+					{
+						if (Regex.IsMatch(s, @"[a-z]{2}-[A-Z]{2}")) return true;
 
-					//	Console.Write("Please enter a valid locale (xx-XX format): ");
-					//	return false;
-					//}) : this.Locale,
-					//OneSync = this.OneSync ?? Input.Bool("enable OneSync", true),
-					//Tags = (string.IsNullOrWhiteSpace(this.Tags) ? Input.String("server tags (separate with space)", "NFive") : this.Tags).Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Distinct().ToList(),
-					//LicenseKey = string.IsNullOrWhiteSpace(this.LicenseKey) ? Input.String("server license key (https://keymaster.fivem.net/)", s =>
-					//{
-					//	if (Regex.IsMatch(s, @"[\d\w]{32}")) return true;
+						Console.Write("Please enter a valid locale (xx-XX format): ");
+						return false;
+					}) : this.Locale,
+					OneSync = this.OneSync ?? Input.Bool("enable OneSync", true),
+					Tags = (string.IsNullOrWhiteSpace(this.Tags) ? Input.String("server tags (separate with space)", "NFive") : this.Tags).Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Distinct().ToList(),
+					LicenseKey = string.IsNullOrWhiteSpace(this.LicenseKey) ? Input.String("server license key (https://keymaster.fivem.net/)", s =>
+					{
+						if (Regex.IsMatch(s, @"[\d\w]{32}")) return true;
 
-					//	Console.Write("Please enter a valid license key: ");
-					//	return false;
-					//}).ToLowerInvariant() : this.LicenseKey,
-					//SteamKey = string.IsNullOrWhiteSpace(this.SteamKey) ? Regex.Replace(Input.String("Steam API license key (https://steamcommunity.com/dev/apikey)", "<disabled>", s =>
-					//{
-					//	if (s == "<disabled>") return true;
-					//	if (s == "none") return true;
-					//	if (Regex.IsMatch(s, @"[0-9a-fA-F]{32}")) return true;
+						Console.Write("Please enter a valid license key: ");
+						return false;
+					}).ToLowerInvariant() : this.LicenseKey,
+					SteamKey = string.IsNullOrWhiteSpace(this.SteamKey) ? Regex.Replace(Input.String("Steam API license key (https://steamcommunity.com/dev/apikey)", "<disabled>", s =>
+					{
+						if (s == "<disabled>") return true;
+						if (s == "none") return true;
+						if (Regex.IsMatch(s, @"[0-9a-fA-F]{32}")) return true;
 
-					//	Console.Write("Please enter a valid Steam API license key: ");
-					//	return false;
-					//}), "^<disabled>$", "none") : this.SteamKey,
-					//RconPassword = string.IsNullOrWhiteSpace(this.RconPassword) ? Regex.Replace(Input.Password("RCON password", "<disabled>"), "^<disabled>$", string.Empty) : this.RconPassword
+						Console.Write("Please enter a valid Steam API license key: ");
+						return false;
+					}), "^<disabled>$", "none") : this.SteamKey,
+					RconPassword = string.IsNullOrWhiteSpace(this.RconPassword) ? Regex.Replace(Input.Password("RCON password", "<disabled>"), "^<disabled>$", string.Empty) : this.RconPassword
 				};
 
 				Directory.CreateDirectory(RuntimeEnvironment.IsWindows ? this.Location : Path.Combine(this.Location, "alpine", "opt", "cfx-server"));

--- a/src/Modules/Setup.cs
+++ b/src/Modules/Setup.cs
@@ -188,20 +188,11 @@ namespace NFive.PluginManager.Modules
 
 			return 0;
 		}
-		private string ServerFileRegexTokens(bool isWindows)
-		{
-			if (isWindows)
-			{
-				return $"({Regex.Escape("server.zip")}|{Regex.Escape("server.7z")})";
-			}
-
-			return Regex.Escape("fx.tar.xz");
-		}
 
 		private async Task InstallFiveM(string path, string source)
 		{
 			var platformName = RuntimeEnvironment.IsWindows ? "Windows" : "Linux";
-			var platformUrl = RuntimeEnvironment.IsWindows ? "build_server_windows" : "build_proot_linux";
+			var platformFile = RuntimeEnvironment.IsWindows ? $"({Regex.Escape("server.zip")}|{Regex.Escape("server.7z")})" : "(fx.tar.xz)";
 			var platformFile = ServerFileRegexTokens(RuntimeEnvironment.IsWindows);
 			var platformPath = RuntimeEnvironment.IsWindows ? Path.Combine(path) : Path.Combine(path, "alpine", "opt", "cfx-server");
 

--- a/src/Modules/Setup.cs
+++ b/src/Modules/Setup.cs
@@ -215,12 +215,7 @@ namespace NFive.PluginManager.Modules
 
 				using (var client = new WebClient())
 				{
-<<<<<<< HEAD
 					var page = await client.DownloadStringTaskAsync($"https://runtime.fivem.net/artifacts/fivem/{platformUrl}/master/");
-=======
-					var page = await client.DownloadStringTaskAsync(
-						$"https://runtime.fivem.net/artifacts/fivem/{platformUrl}/master/");
->>>>>>> 1c9c4270d215e1de10e0590d8e96375c847900c7
 					for (var match =
 							new Regex(
 								$"href= *\"\\./(\\d+)-([a-f0-9]{{40}})/{platformFileGroupPattern}\"( class=\"button is-link is-primary)?( class=\"button is-link is-danger)?",


### PR DESCRIPTION
The setup file archive types have changed to 7z since 3434.
In this PR I've changed windows filename to be either server.zip or server.7z. Conditionals have to be wrapped with ( ) which pushes the token indices out by 1 so incremented the group indices for recommend and optional versions.
Added an optional space after the http= to cater for a mismatch which is on the current version of the downloads page.
![image](https://user-images.githubusercontent.com/6404476/124864494-570aa480-dffc-11eb-928b-c2da3ae14c40.png)

The bintray service is now JFrog and the links compiled into nfpm fail to download the NFive release. If you try to run nfpm even without this PR merged in nfpm fails at the NFive install step. You should approve this PR based on whether the server.7z downloads and decompresses correctly, not whether the whole process works. I've forked all repositories from github.com/NFive and will progressively work through to try to fix things. So far I've built and release a v1.0 of nfive which I'm testing. If you use the following code then you'll at least be able to see nfpm complete successfully. I'll work on the GitHub adapter to get it workign out the version number to use in the version token.

```
private static async Task InstallNFive(string path)
{
	Console.WriteLine("Finding latest NFive version...");

	// The NFive build pipeline will put the version into the filename
	//var version = (await Adapters.Bintray.Version.Get("nfive/NFive/NFive")).Name;
	var version = "1.0";
	var data = await DownloadCached($"https://github.com/HTB-5M/NFive/releases/latest/download/nfive_{version}.zip", "NFive", version, $"nfive_{version}.zip");

	Install(path, "NFive", data.Item1);
}

```

	